### PR TITLE
fix: persist user sessions on mobile devices by setting `maxAge` on cookie to prevent reset on browser close

### DIFF
--- a/app/utils/user-prefs.server.ts
+++ b/app/utils/user-prefs.server.ts
@@ -81,4 +81,3 @@ async function getUserPrefs(request: Request) {
 
 export type { UserPrefs }
 export { userPrefsCookie, getUserPrefs }
-

--- a/app/utils/user-prefs.server.ts
+++ b/app/utils/user-prefs.server.ts
@@ -40,7 +40,9 @@ const defaultUserPrefs: UserPrefs = {
 	},
 }
 
-const userPrefsCookie = createCookie("user-prefs")
+const userPrefsCookie = createCookie("user-prefs", {
+	maxAge: 15_768_000, // 6 months
+})
 
 async function getUserPrefs(request: Request) {
 	const cookieHeader = request.headers.get("Cookie")
@@ -79,3 +81,4 @@ async function getUserPrefs(request: Request) {
 
 export type { UserPrefs }
 export { userPrefsCookie, getUserPrefs }
+

--- a/server.ts
+++ b/server.ts
@@ -18,6 +18,7 @@ export const onRequest = createPagesFunctionHandler<Env>({
 				sameSite: "lax",
 				secrets: [context.env.SESSION_SECRET],
 				secure: process.env.NODE_ENV === "production",
+				maxAge: 15_768_000, // 6 months
 			},
 		}),
 		db: connect({


### PR DESCRIPTION
I don't know why the problems only happen on mobile(or some browser), but setting `maxAge` on the session cookie should been there anyway. 